### PR TITLE
Remove "Stats" option from card dropdown

### DIFF
--- a/src/renderer/components/Card.tsx
+++ b/src/renderer/components/Card.tsx
@@ -10,15 +10,9 @@ import CardEditor from './CardEditor';
 
 const Card = (props: ICardProps) => {
     const [showEditor, setShowEditor] = React.useState<boolean>(false);
-    const [showStats, setShowStats] = React.useState<boolean>(false);
 
     const toggleEditor = () => {
         setShowEditor(show => !show);
-        if (props.onToggleModal !== undefined) props.onToggleModal();
-    }
-
-    const toggleStats = () => {
-        setShowStats(show => !show);
         if (props.onToggleModal !== undefined) props.onToggleModal();
     }
 
@@ -32,7 +26,6 @@ const Card = (props: ICardProps) => {
             <CardView front={props.card.front} back={props.card.back} showBack={props.showBack}>
                 <Dropdown name="" icon="more_horiz" className="card-dropdown" showDownArrow={false}>
                     <DropdownItem name="Edit" icon="edit" action={toggleEditor} />
-                    <DropdownItem name="Stats" icon="assessment" action={toggleStats} />
                     <DropdownItem name="Delete" icon="delete" action={onDelete} />
                 </Dropdown>
 
@@ -45,28 +38,6 @@ const Card = (props: ICardProps) => {
                     onCancel={toggleEditor}
                     card={props.card}
                 />
-            </Modal>
-
-            <Modal show={showStats} onClickOutside={toggleStats}>
-                <h2>Stats</h2>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Attempts</th>
-                            <th>Successes</th>
-                            <th>Retention Rate</th>
-                            <th>Due date</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>{props.card.attempts}</td>
-                            <td>{props.card.successes}</td>
-                            <td>{props.card.attempts === 0 ? "N/A" : `${Math.round(props.card.retentionRate() * 100)}%`}</td>
-                            <td>{props.card.dueDate.toLocaleDateString()}</td>
-                        </tr>
-                    </tbody>
-                </table>
             </Modal>
         </>
     );


### PR DESCRIPTION
I suggest holding off on approving this for now. Might be useful later on for possible depiction of successful completion of tasks. 

We can merge this once all the other basics are done. 